### PR TITLE
Fix of ConcurrentModificationException in CDOLockUtil when there are concurrent readers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# cdo
+CDO Model Repository project repository (cdo)
+
+Forked the CDO repository and created this branch in order to try to fix 
+
+```
+java.util.ConcurrentModificationException
+        at java.util.HashMap$HashIterator.nextNode(Unknown Source)
+        at java.util.HashMap$KeyIterator.next(Unknown Source)
+        at java.util.Collections$UnmodifiableCollection$1.next(Unknown Source)
+        at org.eclipse.emf.cdo.common.lock.CDOLockUtil.createLockState(CDOLockUtil.java:67)
+        at org.eclipse.emf.cdo.internal.server.Repository.toCDOLockStates(Repository.java:1983)
+        at org.eclipse.emf.cdo.internal.server.Repository.doUnlock(Repository.java:2020)
+        at org.eclipse.emf.cdo.internal.server.Repository.unlock(Repository.java:2004)
+        at org.eclipse.emf.cdo.server.internal.net4j.protocol.UnlockObjectsIndication.indicating(UnlockObjectsIndication.java:71)
+        at org.eclipse.emf.cdo.server.internal.net4j.protocol.CDOServerIndication.indicating(CDOServerIndication.java:108)
+        at org.eclipse.net4j.signal.IndicationWithResponse.doExtendedInput(IndicationWithResponse.java:100)
+        at org.eclipse.net4j.signal.Signal.doInput(Signal.java:377)
+        at org.eclipse.net4j.signal.IndicationWithResponse.execute(IndicationWithResponse.java:73)
+        at org.eclipse.emf.cdo.server.internal.net4j.protocol.CDOServerWriteIndication.execute(CDOServerWriteIndication.java:39)
+```
+
+[Additional info](https://www.eclipse.org/forums/index.php/m/1771560/#msg_1771560)

--- a/plugins/org.eclipse.emf.cdo.common/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.cdo.common/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.emf.cdo.common
-Bundle-Version: 4.6.0.qualifier
+Bundle-Version: 4.6.1.qualifier
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/plugins/org.eclipse.net4j.util/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.net4j.util/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.net4j.util;singleton:=true
-Bundle-Version: 3.7.0.qualifier
+Bundle-Version: 3.7.1.qualifier
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/plugins/org.eclipse.net4j.util/src/org/eclipse/net4j/util/collection/ConcurrentHashBag.java
+++ b/plugins/org.eclipse.net4j.util/src/org/eclipse/net4j/util/collection/ConcurrentHashBag.java
@@ -1,0 +1,251 @@
+package org.eclipse.net4j.util.collection;
+
+import java.util.Collection;
+import java.util.Set;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+/**
+ * Protects target {@link HashBag} using {@link ReadWriteLock}.
+ * This class does not implement {@link Set} interface because iterator is not supported - forEach() method replaces iteration.
+ * Also some default methods are not implemented for brevity.
+ * @author Pavel Vlasov
+ */
+public class ConcurrentHashBag<T>
+{
+
+  private ReadWriteLock readWriteLock = new ReentrantReadWriteLock();
+
+  private HashBag<T> target;
+
+  public ConcurrentHashBag(HashBag<T> target)
+  {
+    this.target = target;
+  }
+
+  public int getCounterFor(T o)
+  {
+    readWriteLock.readLock().lock();
+    try
+    {
+      return target.getCounterFor(o);
+    }
+    finally
+    {
+      readWriteLock.readLock().unlock();
+    }
+  }
+
+  /**
+   * TODO Replace with java.util.function.Consumer when upgrading bundle compatibility level to 1.8
+   * @author Pavel Vlasov
+   */
+  public interface Consumer<T>
+  {
+
+    void accept(T obj);
+
+  }
+
+  public void forEach(Consumer<? super T> action)
+  {
+    readWriteLock.readLock().lock();
+    try
+    {
+      for (T e : target)
+      {
+        action.accept(e);
+      }
+    }
+    finally
+    {
+      readWriteLock.readLock().unlock();
+    }
+  }
+
+  public int size()
+  {
+    readWriteLock.readLock().lock();
+    try
+    {
+      return target.size();
+    }
+    finally
+    {
+      readWriteLock.readLock().unlock();
+    }
+  }
+
+  public boolean isEmpty()
+  {
+    readWriteLock.readLock().lock();
+    try
+    {
+      return target.isEmpty();
+    }
+    finally
+    {
+      readWriteLock.readLock().unlock();
+    }
+  }
+
+  public boolean contains(Object o)
+  {
+    readWriteLock.readLock().lock();
+    try
+    {
+      return target.contains(o);
+    }
+    finally
+    {
+      readWriteLock.readLock().unlock();
+    }
+  }
+
+  public Object[] toArray()
+  {
+    readWriteLock.readLock().lock();
+    try
+    {
+      return target.toArray();
+    }
+    finally
+    {
+      readWriteLock.readLock().unlock();
+    }
+  }
+
+  @SuppressWarnings("hiding")
+  public <T> T[] toArray(T[] a)
+  {
+    readWriteLock.readLock().lock();
+    try
+    {
+      return target.toArray(a);
+    }
+    finally
+    {
+      readWriteLock.readLock().unlock();
+    }
+  }
+
+  public boolean add(T e)
+  {
+    readWriteLock.writeLock().lock();
+    try
+    {
+      return target.add(e);
+    }
+    finally
+    {
+      readWriteLock.writeLock().unlock();
+    }
+  }
+
+  public boolean remove(Object o)
+  {
+    readWriteLock.writeLock().lock();
+    try
+    {
+      return target.remove(o);
+    }
+    finally
+    {
+      readWriteLock.writeLock().unlock();
+    }
+  }
+
+  public boolean containsAll(Collection<?> c)
+  {
+    readWriteLock.readLock().lock();
+    try
+    {
+      return target.containsAll(c);
+    }
+    finally
+    {
+      readWriteLock.readLock().unlock();
+    }
+  }
+
+  public boolean addAll(Collection<? extends T> c)
+  {
+    readWriteLock.writeLock().lock();
+    try
+    {
+      return target.addAll(c);
+    }
+    finally
+    {
+      readWriteLock.writeLock().unlock();
+    }
+  }
+
+  public boolean retainAll(Collection<?> c)
+  {
+    readWriteLock.writeLock().lock();
+    try
+    {
+      return target.retainAll(c);
+    }
+    finally
+    {
+      readWriteLock.writeLock().unlock();
+    }
+  }
+
+  public boolean removeAll(Collection<?> c)
+  {
+    readWriteLock.writeLock().lock();
+    try
+    {
+      return target.removeAll(c);
+    }
+    finally
+    {
+      readWriteLock.writeLock().unlock();
+    }
+  }
+
+  public void clear()
+  {
+    readWriteLock.writeLock().lock();
+    try
+    {
+      target.clear();
+    }
+    finally
+    {
+      readWriteLock.writeLock().unlock();
+    }
+  }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    readWriteLock.readLock().lock();
+    try
+    {
+      return target.equals(o);
+    }
+    finally
+    {
+      readWriteLock.readLock().unlock();
+    }
+  }
+
+  @Override
+  public int hashCode()
+  {
+    readWriteLock.readLock().lock();
+    try
+    {
+      return target.hashCode();
+    }
+    finally
+    {
+      readWriteLock.readLock().unlock();
+    }
+  }
+
+}


### PR DESCRIPTION
According to my tests I have reasons to believe that I've fixed the problem which happens when there are multiple threads applying concurrent read locks:

```
java.util.ConcurrentModificationException
        at java.util.HashMap$HashIterator.nextNode(Unknown Source)
        at java.util.HashMap$KeyIterator.next(Unknown Source)
        at java.util.Collections$UnmodifiableCollection$1.next(Unknown Source)
        at org.eclipse.emf.cdo.common.lock.CDOLockUtil.createLockState(CDOLockUtil.java:67)
        at org.eclipse.emf.cdo.internal.server.Repository.toCDOLockStates(Repository.java:1983)
        at org.eclipse.emf.cdo.internal.server.Repository.doUnlock(Repository.java:2020)
        at org.eclipse.emf.cdo.internal.server.Repository.unlock(Repository.java:2004)
        at org.eclipse.emf.cdo.server.internal.net4j.protocol.UnlockObjectsIndication.indicating(UnlockObjectsIndication.java:71)
        at org.eclipse.emf.cdo.server.internal.net4j.protocol.CDOServerIndication.indicating(CDOServerIndication.java:108)
        at org.eclipse.net4j.signal.IndicationWithResponse.doExtendedInput(IndicationWithResponse.java:100)
        at org.eclipse.net4j.signal.Signal.doInput(Signal.java:377)
        at org.eclipse.net4j.signal.IndicationWithResponse.execute(IndicationWithResponse.java:73)
        at org.eclipse.emf.cdo.server.internal.net4j.protocol.CDOServerWriteIndication.execute(CDOServerWriteIndication.java:39)
```

More details -
https://www.eclipse.org/forums/index.php?t=msg&th=1086072&goto=1761211

P2 repository for the fix (contains the two affected bundles) -
http://www.nasdanika.org/products/cdo-4.6.1-fix

How the fix works:

There is a new class ConcurrentHashBag, which protects
its target HashBag with ReadWriteLock.

The ConcurrentHashBag replaces iterator with forEach(Consumer)
so all locking is encapsulated.

RWOLockManager.LockState uses the ConcurrentHashBag and replaces
getReadLockOwners() with forEachReadLockOwner(). 

LockState clients which call getReadLockOwners(),
including CDOLockUtil, are modified to use the new API.

Please review and merge into the main repository. Ignore irrelevant changes such as the README.md and version changes in manifest files.