### PR TITLE
allow approximate statistics for getIndexInfo ...

### DIFF
--- a/plugins/org.eclipse.net4j.db/src/org/eclipse/net4j/spi/db/DBAdapter.java
+++ b/plugins/org.eclipse.net4j.db/src/org/eclipse/net4j/spi/db/DBAdapter.java
@@ -265,7 +265,7 @@ public abstract class DBAdapter implements IDBAdapter
     ResultSet primaryKeys = metaData.getPrimaryKeys(null, schemaName, tableName);
     readIndices(connection, primaryKeys, table, 6, 0, 4, 5);
 
-    ResultSet indexInfo = metaData.getIndexInfo(null, schemaName, tableName, false, false);
+    ResultSet indexInfo = metaData.getIndexInfo(null, schemaName, tableName, false, true);
     readIndices(connection, indexInfo, table, 6, 4, 9, 8);
   }
 


### PR DESCRIPTION
to avoid re-calculating (destroying) table statistics on Oracle.
The exact index statistics are not used by CDO anyway.

This fixes Bug 552510.